### PR TITLE
Refine viewport height and padding for better layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,10 +15,10 @@ html, body {
   overflow: hidden;
   overflow-x: hidden;
 }
-/* Viewport height variable with smart fallback for mobile UI bars */
-:root { --app-minvh: 100svh; }
-@supports (height: 100dvh) {
-  :root { --app-minvh: 100dvh; }
+/* Reliable 90vh variable: prefer 90dvh, fall back to 90svh */
+:root { --app-90vh: 90svh; }
+@supports (height: 90dvh) {
+  :root { --app-90vh: 90dvh; }
 }
 /* #flipbook .page {
   background-color: white;
@@ -39,14 +39,14 @@ html, body {
   flex-direction: column;
   align-items: stretch;
   justify-content: space-between;
-  height: calc(var(--app-minvh) * 0.8);
-  min-height: calc(var(--app-minvh) * 0.8);
-  max-height: calc(var(--app-minvh) * 0.8);
+  height: var(--app-90vh);
+  min-height: var(--app-90vh);
+  max-height: var(--app-90vh);
   max-width: 900px;
   margin-inline: auto;
-  margin-block: clamp(0rem,0vh, 2rem); 
-  padding: 1rem;
-  overflow: auto;
+  margin-block: 0; 
+  padding: clamp(0.25rem, 1vw, 0.75rem);
+  overflow: hidden; /* no page scroll inside container */
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   background-color: white;
   /* border-radius: 12px; */
@@ -102,8 +102,8 @@ h2 span{
   box-sizing: border-box;
 }
 .page-content {
-  padding: 1rem;
-  padding-bottom: 1rem; /* prevent text from being hidden behind footer */
+  padding: clamp(1rem, 1.2vw, 1rem);
+  padding-bottom: clamp(2rem, 6vh, 3rem); /* avoid footer overlap on all screens */
 }
 
 /* Page number inside yellow bar */
@@ -148,6 +148,7 @@ h2 span{
 .title {
   font-size: 1rem;
   font-weight: 600;
+  
 }
 
 .subtitle {
@@ -180,6 +181,7 @@ h2 span{
   font-size: clamp(1rem, 2.5vw, 1.4rem);
   line-height: 1.2;
   margin: 0rem 0;
+  color: #3d3c3c;
 }
 .page h1, .page h2 {
   font-size: clamp(1rem, 2.5vw, 1.4rem);
@@ -187,6 +189,7 @@ h2 span{
   margin: 0.2rem 0;
   display: flex;
   align-items: center;
+  color: #3d3c3c;
 }
 
 @media (max-width: 500px) {
@@ -195,9 +198,9 @@ h2 span{
     border-radius: 0;
     padding: 0rem;
     /* margin-top: 2rem; */
-    height: calc(var(--app-minvh) * 0.8);
-    min-height: calc(var(--app-minvh) * 0.8);
-    max-height: calc(var(--app-minvh) * 0.8);
+    height: var(--app-90vh);
+    min-height: var(--app-90vh);
+    max-height: var(--app-90vh);
   }
 
   header, footer {
@@ -205,10 +208,10 @@ h2 span{
     padding: 0rem;
   }
 
-  html, body { overflow: auto; overflow-x: hidden; }
+  html, body { overflow: hidden; }
   #flipbook { aspect-ratio: auto; height: 100%; }
   .page { height: 100%; }
-  .page-content { padding-bottom: 2.25rem; }
+  .page-content { padding-bottom: clamp(1.5rem, 5vh, 2.5rem); }
 
   .page p{
     font-size: clamp(0vh, 2.5vw, 1.2rem);
@@ -233,9 +236,9 @@ h2 span{
     border-radius: 0;
     padding: 0rem;
     margin-bottom: 0.5rem;
-    height: calc(var(--app-minvh) * 0.8);
-    min-height: calc(var(--app-minvh) * 0.8);
-    max-height: calc(var(--app-minvh) * 0.8);
+    height: var(--app-90vh);
+    min-height: var(--app-90vh);
+    max-height: var(--app-90vh);
   }
 
   header, footer {
@@ -257,10 +260,10 @@ h2 span{
     line-height: 1.5;
     align-items: center;
   }
-  html, body { overflow: auto; overflow-x: hidden; }
+  html, body { overflow: hidden; }
   #flipbook { aspect-ratio: auto; height: 100%; }
   .page { height: 100%; }
-  .page-content { padding-bottom: 2.25rem; }
+  .page-content { padding-bottom: clamp(1.5rem, 5vh, 2.5rem); }
   h2 span{
   font-size: 1.5vh;margin-top: -0.3vh;
   color: #5B82B2;
@@ -274,9 +277,9 @@ h2 span{
     border-radius: 0;
     padding: 0rem;
     margin-bottom: 0.5rem;
-    height: calc(var(--app-minvh) * 0.8);
-    min-height: calc(var(--app-minvh) * 0.8);
-    max-height: calc(var(--app-minvh) * 0.8);
+    height: var(--app-90vh);
+    min-height: var(--app-90vh);
+    max-height: var(--app-90vh);
   }
 
   header, footer {
@@ -298,10 +301,10 @@ h2 span{
     line-height: 1.5;
     align-items: center;
   }
-  html, body { overflow: auto; overflow-x: hidden; }
+  html, body { overflow: hidden; }
   #flipbook { aspect-ratio: auto; height: 100%; }
   .page { height: 100%; }
-  .page-content { padding-bottom: 2.25rem; }
+  .page-content { padding-bottom: clamp(1.5rem, 5vh, 2.5rem); }
   h2 span{
   font-size: 1.5vh;margin-top: -0.3vh;
   color: #5B82B2;


### PR DESCRIPTION
Replaces --app-minvh with a more reliable --app-90vh variable using 90dvh/90svh for improved viewport height handling across devices. Adjusts container and page-content padding for better spacing and footer overlap prevention, and sets consistent text color for headings. Also updates overflow and margin rules for improved mobile and responsive behavior.